### PR TITLE
Added loc and soc names

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -4,13 +4,11 @@ title: About the Joint MUSE/IRIS science team meeting
 
 # About the Joint MUSE/IRIS science team meeting
 
-## What is the Joint MUSE/IRIS science team meeting?
+The meeting will be held at the SETI institute in Mountain View, CA, not far (about 20 min car ride) from LMSAL in Palo Alto, CA.
+The meeting has no registration fees, and is by invitation only.
 
-Our current understanding of the solar chromosphere, transition region, and corona is rapidly evolving, fueled by increasingly advanced simulations of the coupled solar atmosphere and unprecedented high-resolution observations from ground-based (e.g., SST, DKIST) and space-based (e.g., IRIS, Solar Orbiter/EUI) telescopes.
-
-The purpose of this meeting is to advance our knowledge of the dominant processes driving solar dynamics and heating—and to develop next-generation models—it is essential to rigorously compare simulations with observations, focusing on resolving discrepancies between observed and synthetic spectra.
-
-This joint team meeting provides a dynamic forum for critical comparison, highlighting recent breakthroughs, identifying missing physics, and charting paths toward more realistic simulations, with particular attention to IRIS and the upcoming MUSE mission.
+**NOTE**: This will be a MUSE and IRIS science team meeting, directly in support to the operations of the missions, and is NOT a conference.
+Therefore, for NASA-funded people, this meeting does not need to be entered into the NCTS system for approval.
 
 ## LOC
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -2,20 +2,12 @@
 title: About the Joint MUSE/IRIS science team meeting
 ---
 
-# About the Joint MUSE/IRIS science team meeting
-
-The meeting will be held at the SETI institute in Mountain View, CA, not far (about 20 min car ride) from LMSAL in Palo Alto, CA.
-The meeting has no registration fees, and is by invitation only.
-
-**NOTE**: This will be a MUSE and IRIS science team meeting, directly in support to the operations of the missions, and is NOT a conference.
-Therefore, for NASA-funded people, this meeting does not need to be entered into the NCTS system for approval.
-
 ## LOC
 
+* Juan Martinez Sykora [chair]
 * Rebecca Robinson [co-chair]
 * Vishal Upendran [co-chair]
 * Gabriele Cozzo
-* Juan Martinez Sykora
 * Juraj Lorincik
 * Kyuhyoun Cho
 * Nabil Freij

--- a/docs/about.md
+++ b/docs/about.md
@@ -14,18 +14,24 @@ This joint team meeting provides a dynamic forum for critical comparison, highli
 
 ## LOC
 
+* Rebecca Robinson [co-chair]
+* Vishal Upendran [co-chair]
 * Gabriele Cozzo
 * Juan Martinez Sykora
 * Juraj Lorincik
 * Kyuhyoun Cho
 * Nabil Freij
-* Rebecca Robinson
 * Souvik Bose
-* Vishal Upendran
 
 ## SOC
 
-Names
+* Amy Winebarger
+* Bart De Pontieu
+* Fabio Reale
+* Juan Martinez-Sykora
+* Marco Stangalini
+* Mark Cheung
+* Paola Testa
 
 ## Contact Us
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -243,3 +243,7 @@ thead {
 .sponsor-black {
     background-color: black;
 }
+
+.md-typeset .admonition,.md-typeset details {
+    font-size: 0.8rem;
+}

--- a/docs/useful_info.md
+++ b/docs/useful_info.md
@@ -4,11 +4,20 @@ title: Useful Information
 
 # Attend the Joint MUSE/IRIS science team meeting
 
-## Invite Only
+## Registration
 
-Please fill in:
+!!! warning
 
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLScQMnu1V1aOxilhe7mlyeOGI3LQJ4BfwJ-I1pfiPpk5j_87pA/viewform?embedded=true" width="640" height="1160" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+    The meeting has no registration fees, and is by invitation only.
+
+!!! note
+
+    This will be a MUSE and IRIS science team meeting, directly in support to the operations of the missions, and is NOT a conference.
+    Therefore, for NASA-funded people, this meeting does not need to be entered into the NCTS system for approval.
+
+Please fill in the following form:
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLScQMnu1V1aOxilhe7mlyeOGI3LQJ4BfwJ-I1pfiPpk5j_87pA/viewform?embedded=true" width="640" height="640" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
 
 ## Venue
 
@@ -20,7 +29,7 @@ The Joint MUSE/IRIS science team meeting is being held at the [SETI Institute's 
 
 We have no relationships to any hotel vendor, the following list are ones close to SETI.
 
-* Juraj's House, 400$ a night
+* TBD
 
 ### Food
 


### PR DESCRIPTION
## Summary by Sourcery

Update documentation for the Joint MUSE/IRIS science team meeting with specific location details, meeting context, and updated LOC and SOC member lists

Documentation:
- Added detailed meeting location information
- Clarified meeting purpose and NASA funding note
- Updated Local Organizing Committee (LOC) and Science Organizing Committee (SOC) member lists